### PR TITLE
Install patched version of sandpaper

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -84,4 +84,6 @@ profiles:
 # This space below is where custom yaml items (e.g. pinning
 # sandpaper and varnish versions) should live
 
+# this is carpentries/sandpaper#533 in a fork so it can be kept it up to date with main
+sandpaper: epiverse-trace/sandpaper@patch-renv-github-bug 
 


### PR DESCRIPTION
Note that I don't advocate using forks from the official sandpaper in the long run. This is just a short-term patch which will hopefully gather support to merge https://github.com/carpentries/sandpaper/issues/533 with confidence.

Dependency management in sandpaper is very powerful but also very complex and I think https://github.com/carpentries/sandpaper/issues/533 hasn't been merged out of caution of potential side effects it may have on other portions of the code.

In my organization, we have used this patch for more than 6 months without issues now so it's probably worth a try.