### PR TITLE
Revert to using the official sandpaper version

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -84,7 +84,3 @@ profiles:
 #
 # This space below is where custom yaml items (e.g. pinning
 # sandpaper and varnish versions) should live
-
-# this is carpentries/sandpaper#533 in a fork so it can be kept it up to date with main
-sandpaper: epiverse-trace/sandpaper@patch-renv-github-bug
-


### PR DESCRIPTION
Using the Epiverse-TRACE fork is no longer necessary since https://github.com/carpentries/sandpaper/pull/533 was merged.